### PR TITLE
Fix problem rendering greek characters

### DIFF
--- a/modules/GKB/DBAdaptor.pm
+++ b/modules/GKB/DBAdaptor.pm
@@ -402,7 +402,7 @@ sub new {
     }
     
 
-    my $dbh = eval { DBI->connect($dsn,$user,$password, {RaiseError => 1}); };
+    my $dbh = eval { DBI->connect($dsn,$user,$password, {RaiseError => 1, mysql_enable_utf8 => 1}); };
     if ($@ || !$dbh) {
     	my $throw_string = "Could not connect to database ";
     	if (defined $db) {


### PR DESCRIPTION
Some greek characters did not render correctly. Changing the DBAdaptor to use UTF-8 and changing the PDF generator to use something other than "latin1" seems to have fixed this.
The RTF document generator did not seem to need any specific changes (changing the DBAdaptor appears to have been enough for RTF/Word documents to render correctly).