### PR TITLE
Rewrite of other identifiers retrieval

### DIFF
--- a/modules/GKB/Config_Species.pm
+++ b/modules/GKB/Config_Species.pm
@@ -11,25 +11,6 @@ use Exporter();
 @species = qw(hsap ddis pfal spom scer cele sscr btau cfam mmus rnor ggal xtro drer dmel);
 
 %species_info = (
-    # 'atha' => {
-    #     'name' => ['Arabidopsis thaliana'],
-    #     'refdb' => {'
-    #         dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Arabidopsis_PROTEIN'],
-    #         'url' => 'http://plants.ensembl.org/Arabidopsis_thaliana',
-    #         'access' => 'http://plants.ensembl.org/Arabidopsis_thaliana/Transcript/ProteinSummary?peptide=###ID###',
-    #         'ensg_access' => 'http://plants.ensembl.org/Arabidopsis_thaliana/geneview?gene=###ID###&db=core'
-    #     },
-    #     'alt_refdb' => {
-    #         'dbname' => ['TAIR'],
-    #         'url' => 'http://www.arabidopsis.org/index.jsp',
-    #         'access' => 'http://www.arabidopsis.org/servlets/TairObject?type=locus&name=###ID###',
-    #         'alt_id' => '-TAIR-G'
-    #     }, #regex to remove suffix from ENSG identifier
-    #     'group' => 'Fungi/Plants',
-    #     'mart_url' => 'http://plants.ensembl.org/biomart/martservice',
-    #     'mart_virtual_schema' => 'plants_mart',
-    #     'mart_group' => 'athaliana_eg_gene'
-    # },
     'btau' => {
         'name' => ['Bos taurus'],
         'refdb' => {
@@ -141,19 +122,6 @@ use Exporter();
         'group' => 'Human',
         'mart_group' => 'hsapiens_gene_ensembl'
     },
-    # 'mtub' => {
-    #     'name' => ['Mycobacterium tuberculosis'],
-    #     'pan_name' => 'mycobacterium_tuberculosis_h37rv_asm19595v2',
-    #     'refdb' => {
-    #         'dbname' => ['ENSEMBL', 'Ensembl', 'Ensembl', 'ENSEMBL_M_tuberculosis_PROTEIN'],
-    #         'url' => 'http://bacteria.ensembl.org/Mycobacterium/M_tuberculosis_H37Rv/Info/Index',
-    #         'access' => 'http://bacteria.ensembl.org/Mycobacterium/M_tuberculosis_H37Rv/Transcript/ProteinSummary?peptide=###ID###',
-    #         'ensg_access' => 'http://bacteria.ensembl.org/Mycobacterium/M_tuberculosis_H37Rv/geneview?gene=###ID###&db=core'
-    #     },
-    #     'group' => 'Eubacteria',
-    #     'mart_group' => 'myc_30_gene',
-    #     'prokaryote' => 1
-    # },
     'mmus' => {
         'name' => ['Mus musculus'],
         'refdb' => {
@@ -166,19 +134,6 @@ use Exporter();
         'compara' => 'core',
         'mart_group' => 'mmusculus_gene_ensembl'
     },
-    # 'osat' => {
-    #     'name' => ['Oryza sativa'],
-    #     'refdb' => {
-    #         'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Oryza_sativa_PROTEIN'],
-    #         'url' => 'http://plants.ensembl.org/Oryza_sativa/Info/Index',
-    #         'access' => 'http://plants.ensembl.org/Oryza_sativa/Transcript/ProteinSummary?peptide=###ID###',
-    #         'ensg_access' => 'http://plants.ensembl.org/Oryza_sativa/geneview?gene=###ID###&db=core'
-    #     },
-    #     'group' => 'Fungi/Plants',
-    #     'mart_url' => 'http://plants.ensembl.org/biomart/martservice',
-    #     'mart_virtual_schema' => 'plants_mart',
-    #     'mart_group' => 'osativa_eg_gene'
-    # },
     'pfal' => {
         'name' => ['Plasmodium falciparum'],
         'refdb' => {
@@ -256,18 +211,6 @@ use Exporter();
         'mart_group' => 'sscrofa_gene_ensembl',
         'compara' => 'core'
     },
-    # 'tgut' => {
-    #     'name' => ['Taeniopygia guttata'],
-    #     'refdb' => {
-    #         'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Taeniopygia_guttata_PROTEIN'],
-    #         'url' => 'http://www.ensembl.org/Taeniopygia_guttata/Info/Index/',
-    #         'access' => 'http://www.ensembl.org/Taeniopygia_guttata/Transcript/ProteinSummary?peptide=###ID###',
-    #         'ensg_access' => 'http://www.ensembl.org/Taeniopygia_guttata/geneview?gene=###ID###&db=core'
-    #     },
-    #     'group' => 'Vertebrate',
-    #     'mart_group' => 'tguttata_gene_ensembl',
-    #     'compara' => 'core'
-    # },
     'xtro' => {
         'name' => ['Xenopus tropicalis'],
         'refdb' => {

--- a/modules/GKB/Config_Species.pm
+++ b/modules/GKB/Config_Species.pm
@@ -8,193 +8,279 @@ use Exporter();
 @ISA=qw(Exporter);
 
 #defines the order in which the species should be handled for orthology inference
-@species = qw(hsap ddis pfal spom scer cele sscr btau cfam mmus rnor ggal tgut xtro drer dmel atha osat mtub);
+@species = qw(hsap ddis pfal spom scer cele sscr btau cfam mmus rnor ggal xtro drer dmel);
 
-%species_info = ('atha' => {'name' => ['Arabidopsis thaliana'],
-			    'refdb' => {'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Arabidopsis_PROTEIN'],
-					'url' => 'http://plants.ensembl.org/Arabidopsis_thaliana',
-					'access' => 'http://plants.ensembl.org/Arabidopsis_thaliana/Transcript/ProteinSummary?peptide=###ID###',
-					'ensg_access' => 'http://plants.ensembl.org/Arabidopsis_thaliana/geneview?gene=###ID###&db=core'},
-			    'alt_refdb' => {'dbname' => ['TAIR'],
-					    'url' => 'http://www.arabidopsis.org/index.jsp',
-					    'access' => 'http://www.arabidopsis.org/servlets/TairObject?type=locus&name=###ID###',
-					    'alt_id' => '-TAIR-G'}, #regex to remove suffix from ENSG identifier
-			    'group' => 'Fungi/Plants',
-			    'mart_url' => 'http://plants.ensembl.org/biomart/martservice',
-			    'mart_virtual_schema' => 'plants_mart',
-			    'mart_group' => 'athaliana_eg_gene'},
-		 'btau' => {'name' => ['Bos taurus'],
-			    'refdb' => {'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Bos_taurus_PROTEIN'],
-					'url' => 'http://www.ensembl.org/Bos_taurus/Info/Index/',
-					'access' => 'http://www.ensembl.org/Bos_taurus/Transcript/ProteinSummary?peptide=###ID###',
-					'ensg_access' => 'http://www.ensembl.org/Bos_taurus/geneview?gene=###ID###&db=core'},
-			    'group' => 'Vertebrate',
-			    'compara' => 'core',
-			    'mart_group' => 'btaurus_gene_ensembl'},
-		 'cele' => {'name' => ['Caenorhabditis elegans'],
-			    'refdb' => {'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_C_elegans_PROTEIN'],
-					'url' => 'http://metazoa.ensembl.org/Caenorhabditis_elegans/Info/Index',
-                                        'access' => 'http://metazoa.ensembl.org/Caenorhabditis_elegans/Transcript/ProteinSummary?peptide=###ID###',
-					'ensg_access' => 'http://metazoa.ensembl.org/Caenorhabditis_elegans/geneview?gene=###ID###&db=core'},
-                            'alt_refdb' => {'dbname' => ['Wormbase'],
-                                        'url' => 'http://www.wormbase.org',
-                                        'access' => 'http://www.wormbase.org/db/gene/gene?name=###ID###'},
-                            'group' => 'Metazoan',
-			    'compara' => 'core',
-                            'mart_group' => 'celegans_gene_ensembl'},
-		 'cfam' => {'name' => ['Canis familiaris'],
-                            'refdb' => {'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Canis_PROTEIN'],
-					'url' => 'http://www.ensembl.org/Canis_familiaris/Info/Index/',
-                                        'access' => 'http://www.ensembl.org/Canis_familiaris/Transcript/ProteinSummary?peptide=###ID###',
-					'ensg_access' => 'http://www.ensembl.org/Canis_familiaris/geneview?gene=###ID###&db=core'},
-                            'group' => 'Vertebrate',
-                            'compara' => 'core',
-                            'mart_group' => 'cfamiliaris_gene_ensembl'},
-		 'ddis' => {'name' => ['Dictyostelium discoideum'],
-			    'refdb' => {'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Dictyostelium discoideum_PROTEIN'],
-					'url' => 'http://protists.ensembl.org/Dictyostelium_discoideum/Info/Index',
-					'access' => 'http://protists.ensembl.org/Dictyostelium_discoideum/Transcript/ProteinSummary?peptide=###ID###',
-					'ensg_access' => 'http://protists.ensembl.org/Dictyostelium_discoideum/geneview?gene=###ID###&db=core'},
-			    'alt_refdb' => {'dbname' => ['dictyBase'],
-					    'url' => 'http://www.dictybase.org/',
-					    'access' => 'http://dictybase.org/db/cgi-bin/search/search.pl?query=###ID###'},
-			    'group' => 'Eukaryotes',
-			    'mart_url' => 'http://protists.ensembl.org/biomart/martservice',
-			    'mart_virtual_schema' => 'protists_mart',
-			    'mart_group' => 'ddiscoideum_eg_gene'},
-#			    'mart_group' => 'ddiscoideum_gene'},
-		 'drer' => {'name' => ['Danio rerio'],
-			    'refdb' => {'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Danio_rerio_PROTEIN'],
-                                        'url' => 'http://www.ensembl.org/Danio_rerio/Info/Index/',
-                                        'access' => 'http://www.ensembl.org/Danio_rerio/Transcript/ProteinSummary?peptide=###ID###',
-					'ensg_access' => 'http://www.ensembl.org/Danio_rerio/geneview?gene=###ID###&db=core'},
-                            'group' => 'Vertebrate',
-			    'compara' => 'core',
-			    'mart_group' => 'drerio_gene_ensembl'},
-		 'dmel' => {'name'  => ['Drosophila melanogaster'],
-                            'refdb' => {'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_D_melanogaster_PROTEIN'],
-                                        'url' => 'http://metazoa.ensembl.org/Drosophila_melanogaster',
-                                        'access' => 'http://metazoa.ensembl.org/Drosophila_melanogaster/Transcript/ProteinSummary?peptide=###ID###',
-					'ensg_access' => 'http://metazoa.ensembl.org/Drosophila_melanogaster/geneview?gene=###ID###&db=core'},
-			    'alt_refdb' => {'dbname' => ['Flybase'],
-					    'url' => 'http://www.flybase.net',
-					    'access' => 'http://flybase.net/.bin/fbidq.html?###ID###'},
-                            'group' => 'Metazoan',
-			    'compara' => 'core',
-                            'mart_group' => 'dmelanogaster_gene_ensembl'},
-		 'ggal' => {'name' => ['Gallus gallus'],
-                            'refdb' => {'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Gallus_gallus_PROTEIN'],
-                                        'url' => 'http://www.ensembl.org/Gallus_gallus/Info/Index/',
-                                        'access' => 'http://www.ensembl.org/Gallus_gallus/Transcript/ProteinSummary?peptide=###ID###',
-					'ensg_access' => 'http://www.ensembl.org/Gallus_gallus/geneview?gene=###ID###&db=core'},
-                            'group' => 'Vertebrate',
-			    'compara' => 'core',
-                            'mart_group' => 'ggallus_gene_ensembl'},
-		 'hsap' => {'name' => ['Homo sapiens'],
-			    'refdb' => {'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Homo_sapiens_PROTEIN'],
-                                        'url' => 'http://www.ensembl.org/Homo_sapiens/Info/Index/',
-                                        'access' => 'http://www.ensembl.org/Homo_sapiens/Transcript/ProteinSummary?peptide=###ID###',
-					'ensg_access' => 'http://www.ensembl.org/Homo_sapiens/geneview?gene=###ID###&db=core'},
-                            'group' => 'Human',
-                            'mart_group' => 'hsapiens_gene_ensembl'},
-		 'mtub' => {'name' => ['Mycobacterium tuberculosis'],
-                            'pan_name' => 'mycobacterium_tuberculosis_h37rv_asm19595v2',
-			    'refdb' => {'dbname' => ['ENSEMBL', 'Ensembl', 'Ensembl', 'ENSEMBL_M_tuberculosis_PROTEIN'],
-                                        'url' => 'http://bacteria.ensembl.org/Mycobacterium/M_tuberculosis_H37Rv/Info/Index',
-                                        'access' => 'http://bacteria.ensembl.org/Mycobacterium/M_tuberculosis_H37Rv/Transcript/ProteinSummary?peptide=###ID###',
-					'ensg_access' => 'http://bacteria.ensembl.org/Mycobacterium/M_tuberculosis_H37Rv/geneview?gene=###ID###&db=core'},
-                            'group' => 'Eubacteria',
-                            'mart_group' => 'myc_30_gene',
-                            'prokaryote' => 1},
-		 'mmus' => {'name' => ['Mus musculus'],
-			    'refdb' => {'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Mus_musculus_PROTEIN'],
-                                        'url' => 'http://www.ensembl.org/Mus_musculus/Info/Index/',
-                                        'access' => 'http://www.ensembl.org/Mus_musculus/Transcript/ProteinSummary?peptide=###ID###',
-					'ensg_access' => 'http://www.ensembl.org/Mus_musculus/geneview?gene=###ID###&db=core'},
-                            'group' => 'Vertebrate',
-			    'compara' => 'core',
-                            'mart_group' => 'mmusculus_gene_ensembl'},
-		 'osat' => {'name' => ['Oryza sativa'],
-			    'refdb' => {'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Oryza_sativa_PROTEIN'],
-                                        'url' => 'http://plants.ensembl.org/Oryza_sativa/Info/Index',
-                                        'access' => 'http://plants.ensembl.org/Oryza_sativa/Transcript/ProteinSummary?peptide=###ID###',
-					'ensg_access' => 'http://plants.ensembl.org/Oryza_sativa/geneview?gene=###ID###&db=core'},
-			    'group' => 'Fungi/Plants',
-			    'mart_url' => 'http://plants.ensembl.org/biomart/martservice',
-			    'mart_virtual_schema' => 'plants_mart',
-			    'mart_group' => 'osativa_eg_gene'},
-		 'pfal' => {'name' => ['Plasmodium falciparum'],
-			    'refdb' => {'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_P_falciparum_PROTEIN'],
-                                        'url' => 'http://protists.ensembl.org/Plasmodium_falciparum/Info/Index',
-                                        'access' => 'http://protists.ensembl.org/Plasmodium_falciparum/Transcript/ProteinSummary?peptide=###ID###',
-					'ensg_access' => 'http://protists.ensembl.org/Plasmodium_falciparum/geneview?gene=###ID###&db=core'},
-                            'alt_refdb' => {'dbname' => ['PlasmoDB'],
-					    'url' => 'http://plasmodb.org',
-					    'access' => 'http://plasmodb.org/plasmodb/servlet/sv?page=gene&source_id=###ID###'},
-                           'group' => 'Eukaryotes',
-			    'mart_url' => 'http://protists.ensembl.org/biomart/martservice',
-			    'mart_virtual_schema' => 'protists_mart',
-                            'mart_group' => 'pfalciparum_eg_gene'},
-#                            'mart_group' => 'pfalciparum_gene'},
-		 'rnor' => {'name' => ['Rattus norvegicus'],
-			    'refdb' => {'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Rattus_norvegicus_PROTEIN'],
-                                        'url' => 'http://www.ensembl.org/Rattus_norvegicus/Info/Index/',
-                                        'access' => 'http://www.ensembl.org/Rattus_norvegicus/Transcript/ProteinSummary?peptide=###ID###',
-					'ensg_access' => 'http://www.ensembl.org/Rattus_norvegicus/geneview?gene=###ID###&db=core'},
-                            'group' => 'Vertebrate',
-                            'compara' => 'core',
-                            'mart_group' => 'rnorvegicus_gene_ensembl'},
-        'scer' => {'name' => ['Saccharomyces cerevisiae'],
-			    'refdb' => {'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_S_cerevisiae_PROTEIN'],
-                                        'url' => 'http://fungi.ensembl.org/Saccharomyces_cerevisiae/Info/Index',
-                                        'access' => 'http://fungi.ensembl.org/Saccharomyces_cerevisiae/Transcript/ProteinSummary?peptide=###ID###',
-					'ensg_access' => 'http://fungi.ensembl.org/Saccharomyces_cerevisiae/geneview?gene=###ID###&db=core'},
-                            'alt_refdb' => {'dbname' => ['SGD', 'Saccharomyces Genome Database'],
-                                        'url' => 'http://www.yeastgenome.org',
-                                        'access' => 'http://db.yeastgenome.org/cgi-bin/locus.pl?locus=###ID###'},
-                            'group' => 'Fungi/Plants',
-			    'compara' => 'core',
-                            'mart_group' => 'scerevisiae_gene_ensembl'},
-        'spom' => {'name' => ['Schizosaccharomyces pombe'],
-			    'refdb' => {'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_S_pombe_PROTEIN'],
-                                        'url' => 'http://fungi.ensembl.org/Schizosaccharomyces_pombe/Info/Index',
-                                        'access' => 'http://fungi.ensembl.org/Schizosaccharomyces_pombe/Transcript/ProteinSummary?peptide=###ID###',
-					'ensg_access' => 'http://fungi.ensembl.org/Schizosaccharomyces_pombe/geneview?gene=###ID###&db=core'},
-                            'alt_refdb' => {'dbname' => ['GeneDB'],
-                                        'url' => 'http://www.genedb.org/genedb/pombe',
-                                        'access' => 'http://www.genedb.org/genedb/Search?organism=pombe&name=###ID###'},
-                            'group' => 'Fungi/Plants',
-                            'mart_url' => 'http://fungi.ensembl.org/biomart/martservice',
-                            'mart_virtual_schema' => 'fungi_mart',
-                            'mart_group' => 'spombe_eg_gene'},
-		 'sscr' => {'name' => ['Sus scrofa'],
-			    'refdb' => {'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Sus_scrofa_PROTEIN'],
-                                        'url' => 'http://www.ensembl.org/Sus_scrofa/Info/Index/',
-                                        'access' => 'http://www.ensembl.org/Sus_scrofa/Transcript/ProteinSummary?peptide=###ID###',
-                                        'ensg_access' => 'http://www.ensembl.org/Sus_scrofa/geneview?gene=###ID###&db=core'},
-                            'group' => 'Vertebrate',
-                            'mart_group' => 'sscrofa_gene_ensembl',
-                            'compara' => 'core'},
-        'tgut' => {'name' => ['Taeniopygia guttata'],
-                            'refdb' => {'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Taeniopygia_guttata_PROTEIN'],
-                                        'url' => 'http://www.ensembl.org/Taeniopygia_guttata/Info/Index/',
-                                        'access' => 'http://www.ensembl.org/Taeniopygia_guttata/Transcript/ProteinSummary?peptide=###ID###',
-					'ensg_access' => 'http://www.ensembl.org/Taeniopygia_guttata/geneview?gene=###ID###&db=core'},
-                            'group' => 'Vertebrate',
-                            'mart_group' => 'tguttata_gene_ensembl',
-			    'compara' => 'core'},
-		 'xtro' => {'name' => ['Xenopus tropicalis'],
-			    'refdb' => {'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Xenopus_tropicalis_PROTEIN'],
-                                        'url' => 'http://www.ensembl.org/Xenopus_tropicalis/Info/Index/',
-                                        'access' => 'http://www.ensembl.org/Xenopus_tropicalis/Transcript/ProteinSummary?peptide=###ID###',
-					'ensg_access' => 'http://www.ensembl.org/Xenopus_tropicalis/geneview?gene=###ID###&db=core'},
-                            'group' => 'Vertebrate',
-                            'compara' => 'core',
-                            'mart_group' => 'xtropicalis_gene_ensembl'},
-		 );
-
+%species_info = (
+    # 'atha' => {
+    #     'name' => ['Arabidopsis thaliana'],
+    #     'refdb' => {'
+    #         dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Arabidopsis_PROTEIN'],
+    #         'url' => 'http://plants.ensembl.org/Arabidopsis_thaliana',
+    #         'access' => 'http://plants.ensembl.org/Arabidopsis_thaliana/Transcript/ProteinSummary?peptide=###ID###',
+    #         'ensg_access' => 'http://plants.ensembl.org/Arabidopsis_thaliana/geneview?gene=###ID###&db=core'
+    #     },
+    #     'alt_refdb' => {
+    #         'dbname' => ['TAIR'],
+    #         'url' => 'http://www.arabidopsis.org/index.jsp',
+    #         'access' => 'http://www.arabidopsis.org/servlets/TairObject?type=locus&name=###ID###',
+    #         'alt_id' => '-TAIR-G'
+    #     }, #regex to remove suffix from ENSG identifier
+    #     'group' => 'Fungi/Plants',
+    #     'mart_url' => 'http://plants.ensembl.org/biomart/martservice',
+    #     'mart_virtual_schema' => 'plants_mart',
+    #     'mart_group' => 'athaliana_eg_gene'
+    # },
+    'btau' => {
+        'name' => ['Bos taurus'],
+        'refdb' => {
+            'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Bos_taurus_PROTEIN'],
+            'url' => 'http://www.ensembl.org/Bos_taurus/Info/Index/',
+            'access' => 'http://www.ensembl.org/Bos_taurus/Transcript/ProteinSummary?peptide=###ID###',
+            'ensg_access' => 'http://www.ensembl.org/Bos_taurus/geneview?gene=###ID###&db=core'
+        },
+        'group' => 'Vertebrate',
+        'compara' => 'core',
+        'mart_group' => 'btaurus_gene_ensembl'
+    },
+    'cele' => {
+        'name' => ['Caenorhabditis elegans'],
+        'refdb' => {
+            'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_C_elegans_PROTEIN'],
+            'url' => 'http://metazoa.ensembl.org/Caenorhabditis_elegans/Info/Index',
+            'access' => 'http://metazoa.ensembl.org/Caenorhabditis_elegans/Transcript/ProteinSummary?peptide=###ID###',
+            'ensg_access' => 'http://metazoa.ensembl.org/Caenorhabditis_elegans/geneview?gene=###ID###&db=core'
+        },
+        'alt_refdb' => {
+            'dbname' => ['Wormbase'],
+            'url' => 'http://www.wormbase.org',
+            'access' => 'http://www.wormbase.org/db/gene/gene?name=###ID###'
+        },
+        'group' => 'Metazoan',
+        'compara' => 'core',
+        'mart_group' => 'celegans_gene_ensembl'
+    },
+    'cfam' => {
+        'name' => ['Canis familiaris'],
+        'refdb' => {
+            'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Canis_PROTEIN'],
+            'url' => 'http://www.ensembl.org/Canis_familiaris/Info/Index/',
+            'access' => 'http://www.ensembl.org/Canis_familiaris/Transcript/ProteinSummary?peptide=###ID###',
+            'ensg_access' => 'http://www.ensembl.org/Canis_familiaris/geneview?gene=###ID###&db=core'
+        },
+        'group' => 'Vertebrate',
+        'compara' => 'core',
+        'mart_group' => 'cfamiliaris_gene_ensembl'
+    },
+    'ddis' => {
+        'name' => ['Dictyostelium discoideum'],
+        'refdb' => {
+            'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Dictyostelium discoideum_PROTEIN'],
+            'url' => 'http://protists.ensembl.org/Dictyostelium_discoideum/Info/Index',
+            'access' => 'http://protists.ensembl.org/Dictyostelium_discoideum/Transcript/ProteinSummary?peptide=###ID###',
+            'ensg_access' => 'http://protists.ensembl.org/Dictyostelium_discoideum/geneview?gene=###ID###&db=core'
+        },
+        'alt_refdb' => {
+            'dbname' => ['dictyBase'],
+            'url' => 'http://www.dictybase.org/',
+            'access' => 'http://dictybase.org/db/cgi-bin/search/search.pl?query=###ID###'
+        },
+        'group' => 'Eukaryotes',
+        'mart_url' => 'http://protists.ensembl.org/biomart/martservice',
+        'mart_virtual_schema' => 'protists_mart',
+        'mart_group' => 'ddiscoideum_eg_gene'
+    },
+    'drer' => {
+        'name' => ['Danio rerio'],
+        'refdb' => {
+            'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Danio_rerio_PROTEIN'],
+            'url' => 'http://www.ensembl.org/Danio_rerio/Info/Index/',
+            'access' => 'http://www.ensembl.org/Danio_rerio/Transcript/ProteinSummary?peptide=###ID###',
+            'ensg_access' => 'http://www.ensembl.org/Danio_rerio/geneview?gene=###ID###&db=core'
+        },
+        'group' => 'Vertebrate',
+        'compara' => 'core',
+        'mart_group' => 'drerio_gene_ensembl'
+    },
+    'dmel' => {
+        'name'  => ['Drosophila melanogaster'],
+        'refdb' => {
+            'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_D_melanogaster_PROTEIN'],
+            'url' => 'http://metazoa.ensembl.org/Drosophila_melanogaster',
+            'access' => 'http://metazoa.ensembl.org/Drosophila_melanogaster/Transcript/ProteinSummary?peptide=###ID###',
+            'ensg_access' => 'http://metazoa.ensembl.org/Drosophila_melanogaster/geneview?gene=###ID###&db=core'
+        },
+        'alt_refdb' => {
+            'dbname' => ['Flybase'],
+            'url' => 'http://www.flybase.net',
+            'access' => 'http://flybase.net/.bin/fbidq.html?###ID###'
+        },
+        'group' => 'Metazoan',
+        'compara' => 'core',
+        'mart_group' => 'dmelanogaster_gene_ensembl'
+    },
+    'ggal' => {
+        'name' => ['Gallus gallus'],
+        'refdb' => {
+            'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Gallus_gallus_PROTEIN'],
+            'url' => 'http://www.ensembl.org/Gallus_gallus/Info/Index/',
+            'access' => 'http://www.ensembl.org/Gallus_gallus/Transcript/ProteinSummary?peptide=###ID###',
+            'ensg_access' => 'http://www.ensembl.org/Gallus_gallus/geneview?gene=###ID###&db=core'
+        },
+        'group' => 'Vertebrate',
+        'compara' => 'core',
+        'mart_group' => 'ggallus_gene_ensembl'
+    },
+    'hsap' => {
+        'name' => ['Homo sapiens'],
+        'refdb' => {
+            'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Homo_sapiens_PROTEIN'],
+            'url' => 'http://www.ensembl.org/Homo_sapiens/Info/Index/',
+            'access' => 'http://www.ensembl.org/Homo_sapiens/Transcript/ProteinSummary?peptide=###ID###',
+            'ensg_access' => 'http://www.ensembl.org/Homo_sapiens/geneview?gene=###ID###&db=core'
+        },
+        'group' => 'Human',
+        'mart_group' => 'hsapiens_gene_ensembl'
+    },
+    # 'mtub' => {
+    #     'name' => ['Mycobacterium tuberculosis'],
+    #     'pan_name' => 'mycobacterium_tuberculosis_h37rv_asm19595v2',
+    #     'refdb' => {
+    #         'dbname' => ['ENSEMBL', 'Ensembl', 'Ensembl', 'ENSEMBL_M_tuberculosis_PROTEIN'],
+    #         'url' => 'http://bacteria.ensembl.org/Mycobacterium/M_tuberculosis_H37Rv/Info/Index',
+    #         'access' => 'http://bacteria.ensembl.org/Mycobacterium/M_tuberculosis_H37Rv/Transcript/ProteinSummary?peptide=###ID###',
+    #         'ensg_access' => 'http://bacteria.ensembl.org/Mycobacterium/M_tuberculosis_H37Rv/geneview?gene=###ID###&db=core'
+    #     },
+    #     'group' => 'Eubacteria',
+    #     'mart_group' => 'myc_30_gene',
+    #     'prokaryote' => 1
+    # },
+    'mmus' => {
+        'name' => ['Mus musculus'],
+        'refdb' => {
+            'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Mus_musculus_PROTEIN'],
+            'url' => 'http://www.ensembl.org/Mus_musculus/Info/Index/',
+            'access' => 'http://www.ensembl.org/Mus_musculus/Transcript/ProteinSummary?peptide=###ID###',
+            'ensg_access' => 'http://www.ensembl.org/Mus_musculus/geneview?gene=###ID###&db=core'
+        },
+        'group' => 'Vertebrate',
+        'compara' => 'core',
+        'mart_group' => 'mmusculus_gene_ensembl'
+    },
+    # 'osat' => {
+    #     'name' => ['Oryza sativa'],
+    #     'refdb' => {
+    #         'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Oryza_sativa_PROTEIN'],
+    #         'url' => 'http://plants.ensembl.org/Oryza_sativa/Info/Index',
+    #         'access' => 'http://plants.ensembl.org/Oryza_sativa/Transcript/ProteinSummary?peptide=###ID###',
+    #         'ensg_access' => 'http://plants.ensembl.org/Oryza_sativa/geneview?gene=###ID###&db=core'
+    #     },
+    #     'group' => 'Fungi/Plants',
+    #     'mart_url' => 'http://plants.ensembl.org/biomart/martservice',
+    #     'mart_virtual_schema' => 'plants_mart',
+    #     'mart_group' => 'osativa_eg_gene'
+    # },
+    'pfal' => {
+        'name' => ['Plasmodium falciparum'],
+        'refdb' => {
+            'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_P_falciparum_PROTEIN'],
+            'url' => 'http://protists.ensembl.org/Plasmodium_falciparum/Info/Index',
+            'access' => 'http://protists.ensembl.org/Plasmodium_falciparum/Transcript/ProteinSummary?peptide=###ID###',
+            'ensg_access' => 'http://protists.ensembl.org/Plasmodium_falciparum/geneview?gene=###ID###&db=core'
+        },
+        'alt_refdb' => {
+            'dbname' => ['PlasmoDB'],
+            'url' => 'http://plasmodb.org',
+            'access' => 'http://plasmodb.org/plasmodb/servlet/sv?page=gene&source_id=###ID###'
+        },
+        'group' => 'Eukaryotes',
+        'mart_url' => 'http://protists.ensembl.org/biomart/martservice',
+        'mart_virtual_schema' => 'protists_mart',
+        'mart_group' => 'pfalciparum_eg_gene'
+    },
+    'rnor' => {
+        'name' => ['Rattus norvegicus'],
+        'refdb' => {
+            'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Rattus_norvegicus_PROTEIN'],
+            'url' => 'http://www.ensembl.org/Rattus_norvegicus/Info/Index/',
+            'access' => 'http://www.ensembl.org/Rattus_norvegicus/Transcript/ProteinSummary?peptide=###ID###',
+            'ensg_access' => 'http://www.ensembl.org/Rattus_norvegicus/geneview?gene=###ID###&db=core'
+        },
+        'group' => 'Vertebrate',
+        'compara' => 'core',
+        'mart_group' => 'rnorvegicus_gene_ensembl'
+    },
+    'scer' => {
+        'name' => ['Saccharomyces cerevisiae'],
+        'refdb' => {
+            'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_S_cerevisiae_PROTEIN'],
+            'url' => 'http://fungi.ensembl.org/Saccharomyces_cerevisiae/Info/Index',
+            'access' => 'http://fungi.ensembl.org/Saccharomyces_cerevisiae/Transcript/ProteinSummary?peptide=###ID###',
+            'ensg_access' => 'http://fungi.ensembl.org/Saccharomyces_cerevisiae/geneview?gene=###ID###&db=core'
+        },
+        'alt_refdb' => {
+            'dbname' => ['SGD', 'Saccharomyces Genome Database'],
+            'url' => 'http://www.yeastgenome.org',
+            'access' => 'http://db.yeastgenome.org/cgi-bin/locus.pl?locus=###ID###'
+        },
+        'group' => 'Fungi/Plants',
+        'compara' => 'core',
+        'mart_group' => 'scerevisiae_gene_ensembl'
+    },
+    'spom' => {
+        'name' => ['Schizosaccharomyces pombe'],
+        'refdb' => {
+            'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_S_pombe_PROTEIN'],
+            'url' => 'http://fungi.ensembl.org/Schizosaccharomyces_pombe/Info/Index',
+            'access' => 'http://fungi.ensembl.org/Schizosaccharomyces_pombe/Transcript/ProteinSummary?peptide=###ID###',
+            'ensg_access' => 'http://fungi.ensembl.org/Schizosaccharomyces_pombe/geneview?gene=###ID###&db=core'
+        },
+        'alt_refdb' => {
+            'dbname' => ['GeneDB'],
+            'url' => 'http://www.genedb.org/genedb/pombe',
+            'access' => 'http://www.genedb.org/genedb/Search?organism=pombe&name=###ID###'
+        },
+        'group' => 'Fungi/Plants',
+        'mart_url' => 'http://fungi.ensembl.org/biomart/martservice',
+        'mart_virtual_schema' => 'fungi_mart',
+        'mart_group' => 'spombe_eg_gene'
+    },
+    'sscr' => {
+        'name' => ['Sus scrofa'],
+        'refdb' => {
+            'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Sus_scrofa_PROTEIN'],
+            'url' => 'http://www.ensembl.org/Sus_scrofa/Info/Index/',
+            'access' => 'http://www.ensembl.org/Sus_scrofa/Transcript/ProteinSummary?peptide=###ID###',
+            'ensg_access' => 'http://www.ensembl.org/Sus_scrofa/geneview?gene=###ID###&db=core'
+        },
+        'group' => 'Vertebrate',
+        'mart_group' => 'sscrofa_gene_ensembl',
+        'compara' => 'core'
+    },
+    # 'tgut' => {
+    #     'name' => ['Taeniopygia guttata'],
+    #     'refdb' => {
+    #         'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Taeniopygia_guttata_PROTEIN'],
+    #         'url' => 'http://www.ensembl.org/Taeniopygia_guttata/Info/Index/',
+    #         'access' => 'http://www.ensembl.org/Taeniopygia_guttata/Transcript/ProteinSummary?peptide=###ID###',
+    #         'ensg_access' => 'http://www.ensembl.org/Taeniopygia_guttata/geneview?gene=###ID###&db=core'
+    #     },
+    #     'group' => 'Vertebrate',
+    #     'mart_group' => 'tguttata_gene_ensembl',
+    #     'compara' => 'core'
+    # },
+    'xtro' => {
+        'name' => ['Xenopus tropicalis'],
+        'refdb' => {
+            'dbname' => ['ENSEMBL', 'Ensembl', 'ENSEMBL_Xenopus_tropicalis_PROTEIN'],
+            'url' => 'http://www.ensembl.org/Xenopus_tropicalis/Info/Index/',
+            'access' => 'http://www.ensembl.org/Xenopus_tropicalis/Transcript/ProteinSummary?peptide=###ID###',
+            'ensg_access' => 'http://www.ensembl.org/Xenopus_tropicalis/geneview?gene=###ID###&db=core'
+        },
+        'group' => 'Vertebrate',
+        'compara' => 'core',
+        'mart_group' => 'xtropicalis_gene_ensembl'
+    },
+);
 
 @EXPORT = qw(@species %species_info);
-
-
 

--- a/modules/GKB/EnsEMBLMartUtils.pm
+++ b/modules/GKB/EnsEMBLMartUtils.pm
@@ -329,7 +329,7 @@ sub get_identifiers {
     my $ensembl_url = 'http://www.ensembl.org/biomart/martservice?' .
         'type=listAttributes&mart=ENSEMBL_MART_ENSEMBL' .
         '&virtualSchema=default' .
-        "&dataset=$species_gene_ensembl" .
+        '&dataset='.$species.'_gene_ensembl' .
         '&interface=default' .
         '&attributePage=feature_page' .
         '&attributeGroup=external' .

--- a/modules/GKB/EnsEMBLMartUtils.pm
+++ b/modules/GKB/EnsEMBLMartUtils.pm
@@ -264,7 +264,7 @@ sub get_species_mart_name {
     if ($species_name =~ /^(\w)\w+ (\w+)$/) {
         return lc("$1$2");
     } else {
-        $logger->error("Can't form species abbreviation for mart from $species_name\n");
+        $logger->log_confess("Can't form species abbreviation for mart from $species_name\n");
     }
 }
 

--- a/modules/GKB/EnsEMBLMartUtils.pm
+++ b/modules/GKB/EnsEMBLMartUtils.pm
@@ -105,7 +105,9 @@ sub query_for_species_results {
     };
 
     $attribute_with_error = check_for_attribute_error($species_results);
-    if ($attribute_with_error && !$cached_attribute_errors->{$mart_url}{$mart_dataset}{$mart_virtual_schema}{$attribute_with_error}) {
+    if ($attribute_with_error &&
+        !$cached_attribute_errors->{$mart_url}{$mart_dataset}{$mart_virtual_schema}{$attribute_with_error}) {
+
         $cached_attribute_errors->{$mart_url}{$mart_dataset}{$mart_virtual_schema}{$attribute_with_error}++;
         return query_for_species_results(
             $species,
@@ -324,7 +326,14 @@ sub update_registry_file {
 
 sub get_identifiers {
     my $species = shift;
-    my $ensembl_url = 'http://www.ensembl.org/biomart/martservice?type=listAttributes&mart=ENSEMBL_MART_ENSEMBL&virtualSchema=default&dataset='.$species.'_gene_ensembl&interface=default&attributePage=feature_page&attributeGroup=external&attributeCollection=';
+    my $ensembl_url = 'http://www.ensembl.org/biomart/martservice?' .
+        'type=listAttributes&mart=ENSEMBL_MART_ENSEMBL' .
+        '&virtualSchema=default' .
+        "&dataset=$species_gene_ensembl" .
+        '&interface=default' .
+        '&attributePage=feature_page' .
+        '&attributeGroup=external' .
+        '&attributeCollection=';
 
     my @identifiers;
 

--- a/modules/GKB/EnsEMBLMartUtils.pm
+++ b/modules/GKB/EnsEMBLMartUtils.pm
@@ -325,7 +325,8 @@ sub update_registry_file {
 }
 
 sub get_identifiers {
-    my $species = shift;
+    my $species = shift // confess "Need species name in form like 'hsapiens' to retrieve identifiers";
+
     my $ensembl_url = 'http://www.ensembl.org/biomart/martservice?' .
         'type=listAttributes&mart=ENSEMBL_MART_ENSEMBL' .
         '&virtualSchema=default' .

--- a/modules/GKB/EnsEMBLMartUtils.pm
+++ b/modules/GKB/EnsEMBLMartUtils.pm
@@ -264,7 +264,7 @@ sub get_species_mart_name {
     if ($species_name =~ /^(\w)\w+ (\w+)$/) {
         return lc("$1$2");
     } else {
-        $logger->log_confess("Can't form species abbreviation for mart from $species_name\n");
+        $logger->logconfess("Can't form species abbreviation for mart from $species_name\n");
     }
 }
 

--- a/modules/GKB/registry.xml
+++ b/modules/GKB/registry.xml
@@ -1,6 +1,6 @@
 <MartRegistry>
-  <MartURLLocation database="ensembl_mart_94" default="1" displayName="ENSEMBL GENES (SANGER UK)" host="useast.ensembl.org" includeDatasets="" martUser="" name="ENSEMBL_MART_ENSEMBL" path="/biomart/martservice" port="80" serverVirtualSchema="default" visible="1" />
-  <MartURLLocation database="plants_mart_41" default="" displayName="Plant Mart" host="plants.ensembl.org" includeDatasets="" martUser="" name="plants_mart" path="/biomart/martservice" port="80" serverVirtualSchema="plants_mart" visible="1" />  
-  <MartURLLocation database="protists_mart_41" default="" displayName="Protist Mart" host="protists.ensembl.org" includeDatasets="" martUser="" name="protist_mart" path="/biomart/martservice" port="80" serverVirtualSchema="protists_mart" visible="1" />
-  <MartURLLocation database="fungi_mart_41" default="" displayName="Fungal Mart" host="fungi.ensembl.org" includeDatasets="" martUser="" name="fungal_mart" path="/biomart/martservice" port="80" serverVirtualSchema="fungi_mart" visible="1" />
-</MartRegistry>    
+  <MartURLLocation database="ensembl_mart_95" default="1" displayName="ENSEMBL GENES (SANGER UK)" host="useast.ensembl.org" includeDatasets="" martUser="" name="ENSEMBL_MART_ENSEMBL" path="/biomart/martservice" port="80" serverVirtualSchema="default" visible="1" />
+  <MartURLLocation database="plants_mart_42" default="" displayName="Plant Mart" host="plants.ensembl.org" includeDatasets="" martUser="" name="plants_mart" path="/biomart/martservice" port="80" serverVirtualSchema="plants_mart" visible="1" />
+  <MartURLLocation database="protists_mart_42" default="" displayName="Protist Mart" host="protists.ensembl.org" includeDatasets="" martUser="" name="protists_mart" path="/biomart/martservice" port="80" serverVirtualSchema="protists_mart" visible="1" />
+  <MartURLLocation database="fungi_mart_42" default="" displayName="Ensembl Fungi Genes 42" host="fungi.ensembl.org" includeDatasets="" martUser="" name="fungi_mart" path="/biomart/martservice" port="80" serverVirtualSchema="fungi_mart" visible="1" />
+</MartRegistry>

--- a/scripts/release/other_identifiers/indirectIdentifiers_for_all_species.pl
+++ b/scripts/release/other_identifiers/indirectIdentifiers_for_all_species.pl
@@ -1,17 +1,15 @@
-#!/usr/local/bin/perl -w
+#!/usr/bin/perl
 use strict;
+use warnings;
 
 use Data::Dumper;
 use File::Path qw/make_path/;
 use Getopt::Long;
 
-use GKB::Utils;
-use GKB::Instance;
 use GKB::Config;
+use GKB::Config_Species;
 
 $GKB::Config::NO_SCHEMA_VALIDITY_CHECK = undef;
-
-@ARGV || die("Usage: $0 -db db_name ...\n");
 
 my @params = @ARGV;
 
@@ -19,47 +17,38 @@ our ($opt_user, $opt_host, $opt_pass, $opt_port, $opt_db, $opt_debug);
 
 &GetOptions("user:s", "host:s", "pass:s", "port:i", "db:s", "debug");
 
-$opt_db || die "Need database name (-db).\n";    
+$opt_db || die "Need database name (-db).\n";
 
-# Get connection to reactome db
-my $dba = GKB::DBAdaptor->new
-    (
-     -user   => $opt_user,
-     -host   => $opt_host,
-     -pass   => $opt_pass,
-     -port   => $opt_port,
-     -dbname => $opt_db,
-#     -DEBUG => $opt_debug
-     );
-
-my @species = $dba->species_for_ref_dbs('ENSEMBL','UniProt');
-print STDERR "My species:\n", Dumper(\@species);
+print "My species:\n", Dumper(\@species);
 
 make_path('output', { mode => 0775 });
 my @cmds = (
-	qq(./retrieve_indirectIdentifiers_from_mart.pl @params),
-	qq(./indirectIdentifiers_from_mart.pl @params),
-	qq(./gene_names_from_mart.pl @params)
+    qq(./retrieve_indirectIdentifiers_from_mart.pl @params),
+    qq(./indirectIdentifiers_from_mart.pl @params),
+    qq(./gene_names_from_mart.pl @params)
 );
 
 foreach my $sp (@species) {
     foreach my $cmd (@cmds) {
-		my $tmp = "$cmd -sp '$sp'";
-		print STDERR "Command to be run: " . hide_password($tmp) . "\n";
-		system($tmp) == 0 or print(hide_password($tmp) . " failed.\n");
+        my $tmp = "$cmd -sp '$sp'";
+        print "Command to be run: " . hide_password($tmp) . "\n";
+        system($tmp) == 0 or print(hide_password($tmp) . " failed.\n");
     }
 }
 
-print STDERR "$0: no fatal errors.\n";
+print "$0: no fatal errors.\n";
 
 sub hide_password {
     my $string = shift;
-    
+
     $string =~ /-pass (.*?) /;
     my $password = $1;
+
+    if (!$password) {
+        return $string;
+    }
+
     my $asterisks = '*' x 5;
-    
     $string =~ s/-pass $password/-pass $asterisks/;
-    
     return $string;
 }

--- a/scripts/release/other_identifiers/indirectIdentifiers_from_mart.pl
+++ b/scripts/release/other_identifiers/indirectIdentifiers_from_mart.pl
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl
+#!/usr/bin/perl
 use strict;
 use warnings;
 
@@ -9,13 +9,15 @@ use GKB::Config_Species;
 use GKB::EnsEMBLMartUtils qw/get_species_mart_name/;
 use GKB::DBAdaptor;
 use GKB::Utils;
+
 use Data::Dumper;
 use Getopt::Long;
 use Unicode::CaseFold;
 
 our($opt_user,$opt_host,$opt_pass,$opt_port,$opt_db,$opt_debug,$opt_sp);
 
-(@ARGV) || die "Usage: $0 -sp 'species name' -user db_user -host db_host -pass db_pass -port db_port -db db_name\n";
+(@ARGV) || die
+    "Usage: $0 -sp 'species code (e.g. hsap)' -user db_user -host db_host -pass db_pass -port db_port -db db_name\n";
 
 &GetOptions("user:s", "host:s", "pass:s", "port:i", "db:s", "debug", "sp=s");
 

--- a/scripts/release/other_identifiers/indirectIdentifiers_from_mart.pl
+++ b/scripts/release/other_identifiers/indirectIdentifiers_from_mart.pl
@@ -4,6 +4,9 @@ use warnings;
 
 use lib "/usr/local/gkb/modules";
 
+use GKB::Config;
+use GKB::Config_Species;
+use GKB::EnsEMBLMartUtils qw/get_species_mart_name/;
 use GKB::DBAdaptor;
 use GKB::Utils;
 use Data::Dumper;
@@ -16,34 +19,29 @@ our($opt_user,$opt_host,$opt_pass,$opt_port,$opt_db,$opt_debug,$opt_sp);
 
 &GetOptions("user:s", "host:s", "pass:s", "port:i", "db:s", "debug", "sp=s");
 
-$opt_db || die "Need database name (-db).\n";    
+$opt_db || die "Need database name (-db).\n";
+
 
 # Get connection to reactome db
-my $dba = GKB::DBAdaptor->new
-    (
-     -user   => $opt_user,
-     -host   => $opt_host,
-     -pass   => $opt_pass,
-     -port   => $opt_port,
-     -dbname => $opt_db,
+my $dba = GKB::DBAdaptor->new(
+    -user   => $opt_user || $GKB::Config::GK_DB_USER,
+    -host   => $opt_host || $GKB::Config::GK_DB_HOST,
+    -pass   => $opt_pass || $GKB::Config::GK_DB_PASS,
+    -port   => $opt_port || $GKB::Config::GK_DB_PORT,
+    -dbname => $opt_db,
 #     -DEBUG => $opt_debug
-     );
-
-# Fetch the species
-$opt_sp ||= 'Homo sapiens';
-my $sp = $dba->fetch_instance_by_attribute('Species',[['name',[$opt_sp]]])->[0]
-    || die "No species '$opt_sp' found.\n";
-my $sp_mart_name;
-if ($sp->displayName =~ /^(\w)\w+ (\w+)$/) {
-    $sp_mart_name = lc("$1$2");
-} else {
-    die "Can't form species abbreviation for mart from '" . $sp->displayName . "'.\n";
-}
-
+);
 
 # Fetch ReferenceGeneProducts to be "annotated".
 my $protein_class = &GKB::Utils::get_reference_protein_class($dba);
-my $rpss = $dba->fetch_instance_by_attribute($protein_class,[['species',[$sp->db_id]]]);
+
+# Fetch the species
+$opt_sp ||= 'hsap';
+my $sp_mart_name = get_species_mart_name($opt_sp);
+my $species_name = $species_info{$opt_sp}->{'name'}->[0];
+my $species_instance = $dba->fetch_instance_by_attribute('Species',[['name',[$species_name]]])->[0]
+    || die "No species $species_name found.\n";
+my $rpss = $dba->fetch_instance_by_attribute($protein_class,[['species',[$species_instance->db_id]]]);
 # Load the values of an attribute to be updated. Not necessary for the 1st time though.
 $dba->load_class_attribute_values_of_multiple_instances($protein_class,'otherIdentifier',$rpss);
 
@@ -53,24 +51,24 @@ my %uniprot_to_ensp;
 opendir(my $dir, 'output');
 while(my $resource = readdir($dir)) {
     next unless $resource =~ /^$sp_mart_name/;
-    
+
     my $prefix = get_prefix($resource);
     open(my $resource_file, '<', "output/$resource");
     while (my $line = <$resource_file>) {
-	chomp $line;
-	my @identifiers = split /\t/, $line;
-	my $gene = shift @identifiers;
-	my $transcript = shift @identifiers;
-	my $protein = shift @identifiers;
-	my $id = shift @identifiers;
-	$id = $prefix . $id if $id;
-	
-	next unless $transcript;
-	$ensp_to_enst{$protein} = $transcript if $protein;
-	$enst_to_ids{$transcript}{$id}++ if $id;
-	$enst_to_ids{$transcript}{$gene}++ if $gene;
-	$enst_to_ids{$transcript}{$protein}++ if $protein;
-	push @{$uniprot_to_ensp{$id}}, $protein if $resource =~ /sptrembl|swissprot/ && $id;
+        chomp $line;
+        my @identifiers = split /\t/, $line;
+        my $gene = shift @identifiers;
+        my $transcript = shift @identifiers;
+        my $protein = shift @identifiers;
+        my $id = shift @identifiers;
+        $id = $prefix . $id if $id;
+
+        next unless $transcript;
+        $ensp_to_enst{$protein} = $transcript if $protein;
+        $enst_to_ids{$transcript}{$id}++ if $id;
+        $enst_to_ids{$transcript}{$gene}++ if $gene;
+        $enst_to_ids{$transcript}{$protein}++ if $protein;
+        push @{$uniprot_to_ensp{$id}}, $protein if $resource =~ /sptrembl|swissprot/ && $id;
     }
     close $resource_file;
 }
@@ -81,36 +79,36 @@ map {push @{$accs{uc($_->Identifier->[0])}},$_} @{$rpss};
 
 foreach my $rpg_id (keys %accs) {
     foreach my $i (@{$accs{uc($rpg_id)}}) {
-	eval {
-	    my $ref_db = $i->referenceDatabase->[0]->name->[0];
-	    
-	    no warnings 'uninitialized';
-	    my @ensp;
-	    if ($ref_db =~ /ensembl/i) {
-		push @ensp, $rpg_id;
-	    } elsif ($ref_db =~ /uniprot/i) {
-		@ensp = @{$uniprot_to_ensp{$rpg_id}};
-	    }
-	
-	    foreach my $ensp (@ensp) {
-		my $enst = $ensp_to_enst{$ensp};
-		my $ids = $enst_to_ids{$enst};
-		delete $ids->{$rpg_id};
-    
-		$i->add_attribute_value_if_necessary('otherIdentifier', $enst, keys %$ids);
-	    }
-	};
+        eval {
+            my $ref_db = $i->referenceDatabase->[0]->name->[0];
+
+            no warnings 'uninitialized';
+            my @ensp;
+            if ($ref_db =~ /ensembl/i) {
+                push @ensp, $rpg_id;
+            } elsif ($ref_db =~ /uniprot/i) {
+                @ensp = @{$uniprot_to_ensp{$rpg_id}};
+            }
+
+            foreach my $ensp (@ensp) {
+                my $enst = $ensp_to_enst{$ensp};
+                my $ids = $enst_to_ids{$enst};
+                delete $ids->{$rpg_id};
+
+                $i->add_attribute_value_if_necessary('otherIdentifier', $enst, keys %$ids);
+            }
+        };
     }
 }
 
 while (my ($acc,$ar) = each %accs) {
     foreach my $i (@{$ar}) {
-	my @otherIdentifiers = sort {fc($a) cmp fc($b)} grep {defined} @{$i->OtherIdentifier};
-	$i->OtherIdentifier(undef);
-	$i->OtherIdentifier(@otherIdentifiers);
-	
-	print $acc, "\t", join(',',@otherIdentifiers), "\n";
-	$dba->update_attribute($i,'otherIdentifier');
+        my @otherIdentifiers = sort {fc($a) cmp fc($b)} grep {defined} @{$i->OtherIdentifier};
+        $i->OtherIdentifier(undef);
+        $i->OtherIdentifier(@otherIdentifiers);
+
+        print $acc, "\t", join(',',@otherIdentifiers), "\n";
+        $dba->update_attribute($i,'otherIdentifier');
     }
 }
 
@@ -118,14 +116,14 @@ print "$0: no fatal errors.\n";
 
 sub get_prefix {
     my $resource = shift;
-    
+
     if ($resource =~ /_locuslink/i) {
-	return 'LocusLink';
+        return 'LocusLink';
     } elsif ($resource =~ /_entrezgene/i) {
-	return 'EntrezGene:';
+        return 'EntrezGene:';
     } elsif ($resource =~ /_mim/i) {
-	return 'MIM:';
+        return 'MIM:';
     }
-    
+
     return '';
 }

--- a/scripts/release/other_identifiers/retrieve_indirectIdentifiers_from_mart.pl
+++ b/scripts/release/other_identifiers/retrieve_indirectIdentifiers_from_mart.pl
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl
+#!/usr/bin/perl
 use strict;
 use warnings;
 

--- a/scripts/release/other_identifiers/retrieve_indirectIdentifiers_from_mart.pl
+++ b/scripts/release/other_identifiers/retrieve_indirectIdentifiers_from_mart.pl
@@ -29,7 +29,6 @@ if ($help) {
 }
 
 foreach my $species_abbreviation (get_species_to_query($species_abbr)) {
-    next if $species_abbreviation eq 'hsap';
     my $species_mart_name = get_species_mart_name($species_abbreviation);
 
     foreach my $identifier (get_identifiers($species_mart_name)) {

--- a/scripts/release/other_identifiers/retrieve_indirectIdentifiers_from_mart.pl
+++ b/scripts/release/other_identifiers/retrieve_indirectIdentifiers_from_mart.pl
@@ -14,33 +14,38 @@ use List::MoreUtils qw/any/;
 use Try::Tiny;
 
 use Log::Log4perl qw/get_logger/;
-Log::Log4perl->init(\$LOG_CONF);
-my $logger = get_logger(__PACKAGE__);
 
-our($species_code, $help);
+run(@ARGV) unless caller();
 
-&GetOptions(
-    "sp=s" => \$species_code,
-    "help" => \$help
-);
+sub run {
+    Log::Log4perl->init(\$LOG_CONF);
+    my $logger = get_logger(__PACKAGE__);
 
-if ($help) {
-    print usage_instructions();
-    exit;
-}
+    our($species_code, $help);
 
-foreach my $species_abbreviation (get_species_to_query($species_code)) {
-    my $species_mart_name = get_species_mart_name($species_abbreviation);
+    &GetOptions(
+        "sp=s" => \$species_code,
+        "help" => \$help
+    );
 
-    foreach my $identifier (get_identifiers($species_mart_name)) {
-        next if $identifier =~ /chembl|clone_based|dbass|description|ottg|ottt|ottp|shares_cds|merops|mirbase|reactome/;
+    if ($help) {
+        print usage_instructions();
+        exit;
+    }
 
-        my $output_file = "output/$species_mart_name\_$identifier";
-        if (-s $output_file) {
-            $logger->info("$output_file already exists - creating backup");
-            system("mv -f $output_file $output_file.bak");
+    foreach my $species_abbreviation (get_species_to_query($species_code)) {
+        my $species_mart_name = get_species_mart_name($species_abbreviation);
+
+        foreach my $identifier (get_identifiers($species_mart_name)) {
+            next if $identifier =~ /chembl|clone_based|dbass|description|ottg|ottt|ottp|shares_cds|merops|mirbase|reactome/;
+
+            my $output_file = "output/$species_mart_name\_$identifier";
+            if (-s $output_file) {
+                $logger->info("$output_file already exists - creating backup");
+                system("mv -f $output_file $output_file.bak");
+            }
+            download_identifier_file($species_abbreviation, $identifier, $output_file);
         }
-        download_identifier_file($species_abbreviation, $identifier, $output_file);
     }
 }
 
@@ -80,6 +85,33 @@ sub download_identifier_file {
 
     my $logger = get_logger(__PACKAGE__);
 
+    my $results = run_wget_query($species_abbreviation, $identifier);
+
+    my $output = $results->{'output'};
+    my $completion_tag = qr/\[success\]\n/;
+    if ($output =~ /$completion_tag/) {
+        $output =~ s/$completion_tag//;
+        write_output_to_file($output, $output_file);
+    } else {
+        my $error_message = "$identifier for species $species_abbreviation: download of identifier file not complete";
+        if ($attempt_count < $max_attempts) {
+            $logger->warn("$error_message on attempt $attempt_count - retrying");
+            download_identifier_file($species_abbreviation, $identifier, $output_file, ++$attempt_count);
+        } else {
+            my $error = $results->{'error'};
+            $logger->error("$error_message due to $error - aborting");
+        }
+    }
+}
+
+# Runs query to EnsEMBL Mart for species and identifier
+# Returns the output and error from the wget command as a hash reference
+sub run_wget_query {
+    my $species_abbreviation = shift;
+    my $identifier = shift;
+
+    my $logger = get_logger(__PACKAGE__);
+
     my $wget_query = get_wget_query_for_identifier($species_abbreviation, $identifier);
 
     $logger->info("$identifier for species $species_abbreviation: beginning download of identifier file");
@@ -87,22 +119,22 @@ sub download_identifier_file {
         system $wget_query;
     };
 
-    my $completion_tag = qr/\[success\]\n/;
-    if ($output =~ /$completion_tag/) {
-        $output =~ s/$completion_tag//;
+    return {
+        output => $output,
+        error => $error
+    };
+}
 
-        open(my $fh, '>', $output_file);
-        print {$fh} $output;
-        close $fh;
-    } else {
-        my $error_message = "$identifier for species $species_abbreviation: download of identifier file not complete";
-        if ($attempt_count < $max_attempts) {
-            $logger->warn("$error_message on attempt $attempt_count - retrying");
-            download_identifier_file($species_abbreviation, $identifier, $output_file, ++$attempt_count);
-        } else {
-            $logger->error("$error_message due to $error - aborting");
-        }
-    }
+# Write contents of identifier mappings from EnsEMBL Mart to output file
+sub write_output_to_file {
+    my $logger = get_logger(__PACKAGE__);
+
+    my $output = shift // $logger->logconfess("Need output to write to identifier file");
+    my $output_file = shift // $logger->logconfess("Need name of output file");
+
+    open(my $fh, '>', $output_file);
+    print {$fh} $output;
+    close $fh;
 }
 
 sub usage_instructions {
@@ -120,3 +152,5 @@ queried by providing its abbreviation (e.g. hsap for Homo sapiens) with the flag
 Usage: $0 [-sp 'species abbreviation']
 END
 }
+
+1;

--- a/scripts/release/other_identifiers/retrieve_indirectIdentifiers_from_mart.pl
+++ b/scripts/release/other_identifiers/retrieve_indirectIdentifiers_from_mart.pl
@@ -18,7 +18,9 @@ use Log::Log4perl qw/get_logger/;
 # This statement allows the script either to be executed or loaded as a module
 # for testing purposes.
 # https://www.perl.com/article/107/2014/8/7/Rescue-legacy-code-with-modulinos/
-run(@ARGV) if !caller();
+if (!caller()) {
+    run(@ARGV);
+}
 
 sub run {
     Log::Log4perl->init(\$LOG_CONF);

--- a/scripts/release/other_identifiers/retrieve_indirectIdentifiers_from_mart.pl
+++ b/scripts/release/other_identifiers/retrieve_indirectIdentifiers_from_mart.pl
@@ -8,18 +8,19 @@ use GKB::Config;
 use GKB::Config_Species;
 use GKB::EnsEMBLMartUtils qw/get_identifiers get_species_mart_name get_wget_query_for_identifier/;
 
-use Data::Dumper;
+use Capture::Tiny qw/capture/;
 use Getopt::Long;
+use List::MoreUtils qw/any/;
 use Try::Tiny;
 
 use Log::Log4perl qw/get_logger/;
 Log::Log4perl->init(\$LOG_CONF);
 my $logger = get_logger(__PACKAGE__);
 
-our($species_abbr, $help);
+our($species_code, $help);
 
 &GetOptions(
-    "sp=s" => \$species_abbr,
+    "sp=s" => \$species_code,
     "help" => \$help
 );
 
@@ -28,14 +29,18 @@ if ($help) {
     exit;
 }
 
-foreach my $species_abbreviation (get_species_to_query($species_abbr)) {
+foreach my $species_abbreviation (get_species_to_query($species_code)) {
     my $species_mart_name = get_species_mart_name($species_abbreviation);
 
     foreach my $identifier (get_identifiers($species_mart_name)) {
         next if $identifier =~ /chembl|clone_based|dbass|description|ottg|ottt|ottp|shares_cds|merops|mirbase|reactome/;
 
-        my $wget_query = get_wget_query_for_identifier($species_abbreviation, $identifier);
-        system "$wget_query > output/$species_mart_name\_$identifier";
+        my $output_file = "output/$species_mart_name\_$identifier";
+        if (-s $output_file) {
+            $logger->info("$output_file already exists - creating backup");
+            system("mv -f $output_file $output_file.bak");
+        }
+        download_identifier_file($species_abbreviation, $identifier, $output_file);
     }
 }
 
@@ -45,18 +50,59 @@ foreach my $species_abbreviation (get_species_to_query($species_abbr)) {
 sub get_species_to_query {
     my $selected_species = shift;
 
+    my $logger = get_logger(__PACKAGE__);
+
     my @species_to_query;
     if ($selected_species) {
         if (any { $_ eq $selected_species } @species) {
             @species_to_query = ($selected_species);
         } else {
-            $logger->logconfess("EnsEMBL mart information is unknown for $selected_species");
+            $logger->logconfess("$selected_species species: EnsEMBL mart information is unknown");
         }
     } else {
         @species_to_query = @species;
     }
 
     return @species_to_query;
+}
+
+# Retrieves the appropriate wget query for the species and
+# external identifier and then attemps to download the
+# identifier file and save it to an output file.
+# The function will recurse on failure to re-try
+# downloading to a pre-set maximum attempt number
+sub download_identifier_file {
+    my $species_abbreviation = shift;
+    my $identifier = shift;
+    my $output_file = shift;
+    my $attempt_count = shift // 1;
+    my $max_attempts = 3;
+
+    my $logger = get_logger(__PACKAGE__);
+
+    my $wget_query = get_wget_query_for_identifier($species_abbreviation, $identifier);
+
+    $logger->info("$identifier for species $species_abbreviation: beginning download of identifier file");
+    my ($output, $error) = capture {
+        system $wget_query;
+    };
+
+    my $completion_tag = qr/\[success\]\n/;
+    if ($output =~ /$completion_tag/) {
+        $output =~ s/$completion_tag//;
+
+        open(my $fh, '>', $output_file);
+        print {$fh} $output;
+        close $fh;
+    } else {
+        my $error_message = "$identifier for species $species_abbreviation: download of identifier file not complete";
+        if ($attempt_count < $max_attempts) {
+            $logger->warn("$error_message on attempt $attempt_count - retrying");
+            download_identifier_file($species_abbreviation, $identifier, $output_file, ++$attempt_count);
+        } else {
+            $logger->error("$error_message due to $error - aborting");
+        }
+    }
 }
 
 sub usage_instructions {

--- a/scripts/release/other_identifiers/retrieve_indirectIdentifiers_from_mart.pl
+++ b/scripts/release/other_identifiers/retrieve_indirectIdentifiers_from_mart.pl
@@ -15,7 +15,10 @@ use Try::Tiny;
 
 use Log::Log4perl qw/get_logger/;
 
-run(@ARGV) unless caller();
+# This statement allows the script either to be executed or loaded as a module
+# for testing purposes.
+# https://www.perl.com/article/107/2014/8/7/Rescue-legacy-code-with-modulinos/
+run(@ARGV) if !caller();
 
 sub run {
     Log::Log4perl->init(\$LOG_CONF);
@@ -37,6 +40,7 @@ sub run {
         my $species_mart_name = get_species_mart_name($species_abbreviation);
 
         foreach my $identifier (get_identifiers($species_mart_name)) {
+            # TODO: Add these values to a configured skip list in a separate file
             next if $identifier =~ /chembl|clone_based|dbass|description|ottg|ottt|ottp|shares_cds|merops|mirbase|reactome/;
 
             my $output_file = "output/$species_mart_name\_$identifier";

--- a/scripts/release/other_identifiers/t/retrieve_indirectIdentifiers_from_mart.t
+++ b/scripts/release/other_identifiers/t/retrieve_indirectIdentifiers_from_mart.t
@@ -1,0 +1,37 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+
+use File::Spec;
+use Log::Log4perl::Level; # Imports $OFF
+use Path::Tiny qw/path/;
+
+my $script_dir = path($0)->absolute->parent(2)->stringify;
+require_ok(File::Spec->catdir($script_dir, 'retrieve_indirectIdentifiers_from_mart.pl'));
+Log::Log4perl->get_logger(__PACKAGE__)->level($OFF); # Suppress logging during tests
+
+my @species_to_query = get_species_to_query('hsap');
+is(scalar @species_to_query, 1, 'got single species to query');
+is($species_to_query[0], 'hsap', 'single species to query is hsap');
+
+throws_ok { get_species_to_query('xxx') } qr/information is unknown/, 'no species to query for unknown species code';
+
+@species_to_query = get_species_to_query();
+ok(scalar @species_to_query > 1, 'got many species to query');
+ok((grep { $_ eq 'hsap' } @species_to_query), 'got hsap in array of species to query');
+ok((grep { $_ eq 'mmus' } @species_to_query), 'got mmus in array of species to query');
+
+is(get_species_mart_name('hsap'), 'hsapiens', 'got species mart name for hsap');
+
+throws_ok { get_identifiers() } qr/^Need species name/, 'no identifiers without species name';
+my @identifiers = get_identifiers('hsapiens');
+ok(scalar @identifiers > 6, 'got more than default identifiers');
+
+my $results = run_wget_query('hsap', 'ccds');
+like($results->{'output'}, qr/\[success\]/, 'identifier file completely downloaded');
+is($results->{'error'}, '', 'no errors with wget query to EnsEMBL Mart');
+
+done_testing();


### PR DESCRIPTION
The purpose of this pull request is to merge the new logic for querying EnsEMBL Mart for other identifier mappings directly using wget and XML rather than using the no longer supported BioMart Perl API.