### PR TITLE
Go update datamodel changes

### DIFF
--- a/modules/GKB/Release/Steps/GoUpdate.pm
+++ b/modules/GKB/Release/Steps/GoUpdate.pm
@@ -20,32 +20,32 @@ has '+mail' => ( default => sub {
 				}
 );
 
-# override 'run_commands' => sub {
-# 	my ($self) = @_;
-#
-#     $self->cmd("Setting all GO files to have group permissions", [["echo $sudo | sudo -S chgrp gkb *"]]);
-#
-#     $self->cmd("Backing up database",[["mysqldump -u$user -p$pass -h$gkcentral_host --lock_tables=FALSE $gkcentral > $gkcentral\_after_uniprot_update.dump"]]);
-#
-#     my @args = ("-db", $gkcentral, "-host", $gkcentral_host, "-user", $user, "-pass", $pass);
-#
-#     $self->cmd("Running GO obsolete update script",[["perl go_obo_update.pl @args > go.out 2> go.err"]]);
-#     $self->cmd("Running EC number update script",[["perl addEcNumber2Activity_update.pl @args > ec_number.out 2> ec_number.err"]]);
-#
-#     foreach my $class ("GO_MolecularFunction", "GO_BiologicalProcess", "GO_CellularComponent", "PhysicalEntity", "CatalystActivity") {
-#         $self->cmd("Updating $class display names",[["perl updateDisplayName.pl @args -class $class > update_$class.out 2> update_$class.err"]]);
-#     }
-# };
-
 override 'run_commands' => sub {
 	my ($self) = @_;
-	$self->cmd("Backing up database",[["mysqldump -u$user -p$pass -h$gkcentral_host --lock_tables=FALSE $gkcentral > $gkcentral\_before_go_update.dump"]]);
-    $self->cmd("Running GO Update script",
-    	[
- 			["perl run_GO_Update.pl $version  > go.out 2> go.err"]
-    	]
- 	);
-	$self->cmd("Backing up database",[["mysqldump -u$user -p$pass -h$gkcentral_host --lock_tables=FALSE $gkcentral > $gkcentral\_after_go_update.dump"]]);
+
+    $self->cmd("Setting all GO files to have group permissions", [["echo $sudo | sudo -S chgrp gkb *"]]);
+
+    $self->cmd("Backing up database",[["mysqldump -u$user -p$pass -h$gkcentral_host --lock_tables=FALSE $gkcentral > $gkcentral\_after_uniprot_update.dump"]]);
+
+    my @args = ("-db", $gkcentral, "-host", $gkcentral_host, "-user", $user, "-pass", $pass);
+
+    $self->cmd("Running GO obsolete update script",[["perl go_obo_update.pl @args > go.out 2> go.err"]]);
+    $self->cmd("Running EC number update script",[["perl addEcNumber2Activity_update.pl @args > ec_number.out 2> ec_number.err"]]);
+
+    foreach my $class ("GO_MolecularFunction", "GO_BiologicalProcess", "GO_CellularComponent", "PhysicalEntity", "CatalystActivity") {
+        $self->cmd("Updating $class display names",[["perl updateDisplayName.pl @args -class $class > update_$class.out 2> update_$class.err"]]);
+    }
 };
+
+# override 'run_commands' => sub {
+# 	my ($self) = @_;
+# 	$self->cmd("Backing up database",[["mysqldump -u$user -p$pass -h$gkcentral_host --lock_tables=FALSE $gkcentral > $gkcentral\_before_go_update.dump"]]);
+#     $self->cmd("Running GO Update script",
+#     	[
+#  			["perl run_GO_Update.pl $version  > go.out 2> go.err"]
+#     	]
+#  	);
+# 	$self->cmd("Backing up database",[["mysqldump -u$user -p$pass -h$gkcentral_host --lock_tables=FALSE $gkcentral > $gkcentral\_after_go_update.dump"]]);
+# };
 
 1;

--- a/modules/GKB/Release/Steps/GoUpdate.pm
+++ b/modules/GKB/Release/Steps/GoUpdate.pm
@@ -9,32 +9,43 @@ extends qw/GKB::Release::Step/;
 has '+gkb' => ( default => "gkbdev" );
 has '+passwords' => ( default => sub { ['mysql', 'sudo'] } );
 has '+directory' => ( default => "$release/go_update" );
-has '+mail' => ( default => sub { 
+has '+mail' => ( default => sub {
 					my $self = shift;
 					return {
 						'to' => 'curation',
 						'subject' => $self->name,
 						'body' => "",
-						'attachment' => $self->directory . '/go.wiki'
+						'attachment' => $self->directory . "./archive/$version/go_update_logs_R$version.tgz"
 					};
 				}
 );
-						
+
+# override 'run_commands' => sub {
+# 	my ($self) = @_;
+#
+#     $self->cmd("Setting all GO files to have group permissions", [["echo $sudo | sudo -S chgrp gkb *"]]);
+#
+#     $self->cmd("Backing up database",[["mysqldump -u$user -p$pass -h$gkcentral_host --lock_tables=FALSE $gkcentral > $gkcentral\_after_uniprot_update.dump"]]);
+#
+#     my @args = ("-db", $gkcentral, "-host", $gkcentral_host, "-user", $user, "-pass", $pass);
+#
+#     $self->cmd("Running GO obsolete update script",[["perl go_obo_update.pl @args > go.out 2> go.err"]]);
+#     $self->cmd("Running EC number update script",[["perl addEcNumber2Activity_update.pl @args > ec_number.out 2> ec_number.err"]]);
+#
+#     foreach my $class ("GO_MolecularFunction", "GO_BiologicalProcess", "GO_CellularComponent", "PhysicalEntity", "CatalystActivity") {
+#         $self->cmd("Updating $class display names",[["perl updateDisplayName.pl @args -class $class > update_$class.out 2> update_$class.err"]]);
+#     }
+# };
+
 override 'run_commands' => sub {
 	my ($self) = @_;
-
-    $self->cmd("Setting all GO files to have group permissions", [["echo $sudo | sudo -S chgrp gkb *"]]);
-        
-    $self->cmd("Backing up database",[["mysqldump -u$user -p$pass -h$gkcentral_host --lock_tables=FALSE $gkcentral > $gkcentral\_after_uniprot_update.dump"]]);
-        
-    my @args = ("-db", $gkcentral, "-host", $gkcentral_host, "-user", $user, "-pass", $pass);
-    
-    $self->cmd("Running GO obsolete update script",[["perl go_obo_update.pl @args > go.out 2> go.err"]]);
-    $self->cmd("Running EC number update script",[["perl addEcNumber2Activity_update.pl @args > ec_number.out 2> ec_number.err"]]);
-    
-    foreach my $class ("GO_MolecularFunction", "GO_BiologicalProcess", "GO_CellularComponent", "PhysicalEntity", "CatalystActivity") {
-        $self->cmd("Updating $class display names",[["perl updateDisplayName.pl @args -class $class > update_$class.out 2> update_$class.err"]]);
-    }
+	$self->cmd("Backing up database",[["mysqldump -u$user -p$pass -h$gkcentral_host --lock_tables=FALSE $gkcentral > $gkcentral\_before_go_update.dump"]]);
+    $self->cmd("Running GO Update script",
+    	[
+ 			["perl run_GO_Update.pl $version  > go.out 2> go.err"]
+    	]
+ 	);
+	$self->cmd("Backing up database",[["mysqldump -u$user -p$pass -h$gkcentral_host --lock_tables=FALSE $gkcentral > $gkcentral\_after_go_update.dump"]]);
 };
 
 1;

--- a/scripts/release/go_update/go_obo_update.pl
+++ b/scripts/release/go_update/go_obo_update.pl
@@ -515,7 +515,7 @@ sub create_GO_instance {
     $sdi->Name($new_attributes->{'name'});
     $sdi->Definition($new_attributes->{'def'});
     # InstanceOf and ComponentOf are now only valid for GO_CellularComponent
-    if ($GO_instance->is_a("GO_CellularComponent"))
+    if ($sdi->is_a("GO_CellularComponent"))
     {
         $sdi->InstanceOf(undef);
         $sdi->ComponentOf(undef);

--- a/scripts/release/go_update/go_obo_update.pl
+++ b/scripts/release/go_update/go_obo_update.pl
@@ -220,12 +220,12 @@ while (<GO>) {
 
 ## Check for new instances in is_a and part_of
 
-print "Main update is finished, now checking is_a and part_of....\n";
+print "Main update is finished, now checking is_a, part_of, has_part....\n";
 
 my %relationships = ('instanceOf' => \%new_isa,
-		     'componentOf' => \%new_partof,
-		     'hasPart' => \%new_haspart
-		     );
+                     'componentOf' => \%new_partof,
+                     'hasPart' => \%new_haspart
+                    );
 
 foreach my $attribute (keys %relationships) {
     my %new_relationship = %{$relationships{$attribute}};
@@ -241,13 +241,13 @@ foreach my $attribute (keys %relationships) {
                 }
             }
 
-	    my $current_instances = $sdi->attribute_value($attribute);
-	    if (different_go_instances($current_instances, \@new_instances)) {
-	        $sdi->inflate();
-	        $sdi->$attribute(@new_instances);
-	        $dba->update($sdi);
-	    }
-	}
+            my $current_instances = $sdi->attribute_value($attribute);
+            if (different_go_instances($current_instances, \@new_instances)) {
+                $sdi->inflate();
+                $sdi->$attribute(@new_instances);
+                $dba->update($sdi);
+            }
+        }
     }
 }
 
@@ -482,8 +482,12 @@ sub update_GO_instance {
         $GO_instance->inflate();
         $GO_instance->Name($name);
         $GO_instance->Definition($def);
-        $GO_instance->InstanceOf(undef);
-        $GO_instance->ComponentOf(undef);
+        # InstanceOf and ComponentOf are now only valid for GO_CellularComponent
+        if ($GO_instance->is_a("GO_CellularComponent"))
+        {
+            $GO_instance->InstanceOf(undef);
+            $GO_instance->ComponentOf(undef);
+        }
         $GO_instance->Created( @{ $GO_instance->Created } );
         $GO_instance->Modified( @{ $GO_instance->Modified } );
         $GO_instance->add_attribute_value( 'modified', $instance_edit );
@@ -510,8 +514,12 @@ sub create_GO_instance {
     $sdi->modified(undef);
     $sdi->Name($new_attributes->{'name'});
     $sdi->Definition($new_attributes->{'def'});
-    $sdi->InstanceOf(undef);
-    $sdi->ComponentOf(undef);
+    # InstanceOf and ComponentOf are now only valid for GO_CellularComponent
+    if ($GO_instance->is_a("GO_CellularComponent"))
+    {
+        $sdi->InstanceOf(undef);
+        $sdi->ComponentOf(undef);
+    }
     my $ddd = $dba->store($sdi);
 
     return $sdi;

--- a/scripts/release/go_update/run_GO_Update.pl
+++ b/scripts/release/go_update/run_GO_Update.pl
@@ -1,0 +1,92 @@
+#!/usr/local/bin/perl  -w
+use strict;
+
+use lib '/usr/local/gkb/modules';
+use GKB::Config;
+
+use autodie qw/:all/;
+use Cwd;
+use Getopt::Long;
+use Data::Dumper;
+use File::Basename;
+use List::MoreUtils qw/uniq/;
+
+use Log::Log4perl qw/get_logger/;
+
+Log::Log4perl->init(\$LOG_CONF);
+my $logger = get_logger(__PACKAGE__);
+
+my $data_release_pipeline_application_version = "1.0.0";
+my $data_release_pipeline_application = "go-update";
+my $data_release_pipeline_tag = "go-update-1.0.0";
+my $data_release_pipeline_repository = "https://github.com/reactome/data-release-pipeline";
+my $resource_dir = "data-release-pipeline/".$data_release_pipeline_application."/src/main/resources/";
+my $start_directory = cwd(); # abs_path($0);
+
+my $release_version = @args[0];
+
+print "start_directory: ".$start_directory."\n";
+
+if (-e "data-release-pipeline") {
+  $logger->info("data-release-pipeline exists, pulling");
+  # Start on develop. Pull will fail if we're not already on a branch
+  chdir "data-release-pipeline";
+  system("git checkout develop");
+  if (!$data_release_pipeline_tag) {
+    system("git pull");
+  # if there is a tag defined, we should check that out.
+  } else {
+    #chdir "data-release-pipeline";
+    # Still need to do a pull, since the tag might be been created after the last pull
+    system("git pull");
+    system("git checkout ".$data_release_pipeline_tag);
+    #chdir "..";
+  }
+  chdir $start_directory;
+  system("cp ".$data_release_pipeline_application.".properties $resource_dir");
+  chdir "data-release-pipeline";
+} else {
+  $logger->info("Cloning data-release-pipeline");
+  clone_repo();
+  chdir "data-release-pipeline/".$data_release_pipeline_application;
+}
+
+chdir($start_directory."/data-release-pipeline/".$data_release_pipeline_application."/");
+$logger->info("Getting the GO files...")
+system("wget -O ".$resource_dir."go.obo http://current.geneontology.org/ontology/go.obo");
+system("wget -O ".$resource_dir."ec2go http://geneontology.org/external2go/ec2go");
+
+$logger->info("Executing ".$data_release_pipeline_application);
+build_jar_and_execute();
+# system("mv UpdateDOIs.log ../..");
+$logger->info("Finished executing ".$data_release_pipeline_application);
+
+sub clone_repo {
+  system("git clone ".$data_release_pipeline_repository);
+  # if there is a tag defined, we should check that out.
+  if ($data_release_pipeline_tag ne '')
+  {
+    chdir "data-release-pipeline";
+    system("git checkout ".$data_release_pipeline_tag);
+    chdir $start_directory;
+  }
+  system("cp ".$data_release_pipeline_application.".properties $resource_dir");
+}
+
+sub build_jar_and_execute {
+  # Need to build/install release-common-lib first.
+  chdir($start_directory."/data-release-pipeline/");
+  print "currently in: ".cwd()."\n";
+  chdir "release-common-lib";
+  system("mvn clean compile install");
+  chdir "../".$data_release_pipeline_application;
+  system("mvn clean compile assembly:single");
+
+  system("java -jar target/".$data_release_pipeline_application."-".$data_release_pipeline_application_version."-jar-with-dependencies.jar src/main/resources/".$data_release_pipeline_application.".properties");
+  # Move the logs up to the main directory so that they can get archived.
+#  system("cp logs/* ../../");
+  # TODO: Zip all the logs into an archive and then email them when the step finishes, instead of the old go.wiki
+  system("cp -a logs ../../archive/$release_version/logs");
+  system("tar -czf go_update_logs_R$release_version.tgz ../../archive/$release_version/logs");
+
+}


### PR DESCRIPTION
Updates the GO Update script to be in sync with the latest GO_* entity data model changes.

Also includes Perl script to call the _Java_ version of GO Update, because I still don't know which version of GO Update will run in Release 69.

But then there was talk of running the Perl and Java versions in parallel on separate machines to verify that the Java one was correct so, maybe it's OK that this PR contains updated Perl code but also runs the Java, since I guess that is how it will probably be going forward...